### PR TITLE
Update dependencies

### DIFF
--- a/RIN.Core/RIN.Core.csproj
+++ b/RIN.Core/RIN.Core.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.1.28" />
-    <PackageReference Include="Npgsql" Version="8.0.1" />
-    <PackageReference Include="protobuf-net" Version="3.2.30" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Npgsql" Version="8.0.5" />
+    <PackageReference Include="protobuf-net" Version="3.2.45" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
   </ItemGroup>
 

--- a/RIN.InternalAPI/RIN.InternalAPI.csproj
+++ b/RIN.InternalAPI/RIN.InternalAPI.csproj
@@ -11,13 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.57.0" />
-    <PackageReference Include="protobuf-net.Grpc" Version="1.1.1" />
-    <PackageReference Include="protobuf-net.Grpc.AspNetCore" Version="1.1.1" />
-    <PackageReference Include="protobuf-net.Grpc.Reflection" Version="1.1.1" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.66.0" />
+    <PackageReference Include="protobuf-net.Grpc" Version="1.2.2" />
+    <PackageReference Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
+    <PackageReference Include="protobuf-net.Grpc.Reflection" Version="1.2.2" />
     <PackageReference Include="protobuf-net.Reflection" Version="3.2.12" />
-    <PackageReference Include="Serilog" Version="3.1.2-dev-02097" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="4.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RIN.WebAPI/RIN.WebAPI.csproj
+++ b/RIN.WebAPI/RIN.WebAPI.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.1.28" />
+        <PackageReference Include="Dapper" Version="2.1.35" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Npgsql" Version="8.0.1" />
-        <PackageReference Include="protobuf-net" Version="3.2.30" />
-        <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
-        <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Npgsql" Version="8.0.5" />
+        <PackageReference Include="protobuf-net" Version="3.2.45" />
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+        <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated packages to latest stable versions, npgsql 8.0.1 had [one vulnerability](https://www.cve.org/CVERecord?id=CVE-2024-32655).